### PR TITLE
Styling fixes (home vertical, header edges...)

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -101,6 +101,6 @@
 	}
 
 	a:hover {
-		color: var(--color-theme-1);
+		color: var(--color-primary);
 	}
 </style>

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -49,6 +49,7 @@
 		width: 2em;
 		height: 3em;
 		display: block;
+		flex-shrink: 0;
 	}
 
 	path {

--- a/src/components/tiles/AboutApp.svelte
+++ b/src/components/tiles/AboutApp.svelte
@@ -1,11 +1,15 @@
 <h2>About app</h2>
 <p>
-    Curious about the app? The tech stack, features, learnings.
+	Curious about the app? The tech stack, features, learnings.
 </p>
 <a href="/about-app">More...</a>
 
 <style>
-    a {
-        text-align: right;
-    }
+	a {
+		text-align: right;
+	}
+
+	h2 {
+		margin: 0px;
+	}
 </style>

--- a/src/components/tiles/AboutMe.svelte
+++ b/src/components/tiles/AboutMe.svelte
@@ -1,11 +1,16 @@
 <h2>Who wrote this crap?</h2>
 <p>
-    Just a borderline insane frontend dev looking for the next spot to apply my trade.
+	Just a borderline insane frontend dev looking for the next spot to apply my trade.
 </p>
 <a href="/about-me">More...</a>
 
 <style>
-    a {
-        text-align: right;
-    }
+	a {
+		text-align: right;
+	}
+
+	
+	h2 {
+		margin: 0px;
+	}
 </style>

--- a/src/components/tiles/Experiments.svelte
+++ b/src/components/tiles/Experiments.svelte
@@ -1,9 +1,19 @@
 <h2>Experiments</h2>
 <ol>
-    <li>
-        <a href="/experiments/hex-grid-canvas">Hex grid in canvas element</a>
-    </li>
-    <li>
-        <a href="/experiments/wasm-rust">Compiled Rust -&gt; WASM code</a>
-    </li>
+	<li>
+		<a href="/experiments/hex-grid-canvas">Hex grid in canvas element</a>
+	</li>
+	<li>
+		<a href="/experiments/wasm-rust">Compiled Rust -&gt; WASM code</a>
+	</li>
 </ol>
+
+<style>
+	a {
+		text-align: right;
+	}
+
+	h2 {
+		margin: 0px;
+	}
+</style>

--- a/src/components/tiles/MostRecentPosts.svelte
+++ b/src/components/tiles/MostRecentPosts.svelte
@@ -1,36 +1,35 @@
 <script lang="ts">
-	import type { Article } from "$lib/types";
+	import type { Article } from '$lib/types';
 
-    interface ArticlesData {
-        articles: Array<Article>
-    }
+	interface ArticlesData {
+		articles: Array<Article>;
+	}
 
-	export let data: ArticlesData
+	export let data: ArticlesData;
 </script>
 
 <h2>Most recent articles</h2>
 <nav>
-    <ol>
-        {#each data.articles as article}
-            <a href={"/article/" + article.slug}  class="article-recent-link">
-                <li>
-                    <div class="header">
-                        <span class="title">{article.title}</span>
-                    </div>
-                    <div class="footer">
-                        <p class="date">{article.created}</p>
-                    </div>
-                </li>
-            </a>
-        {/each}
-    </ol>
+	<ol>
+		{#each data.articles as article}
+			<a href={'/article/' + article.slug} class="article-recent-link">
+				<li>
+					<div class="header">
+						<span class="title">{article.title}</span>
+					</div>
+					<div class="footer">
+						<p class="date">{article.created}</p>
+					</div>
+				</li>
+			</a>
+		{/each}
+	</ol>
 </nav>
 
 <style>
 	.article-recent-link > li {
 		padding: 0.6rem 0.7rem;
 		border-radius: 1.5rem;
-		border: 2px solid var(--color-theme-2);
 	}
 
 	.article-recent-link .title {
@@ -39,5 +38,9 @@
 
 	.article-recent-link .footer {
 		font-size: 0.8rem;
+	}
+
+	h2 {
+		margin: 0px;
 	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,7 +12,7 @@
 	<meta name="description" content="Digital garden of lalli-oni" />
 </svelte:head>
 
-<main>
+<div class="vertical-stack">
 	<div class="bg-illustration">
 		<img src="/cloud-illustration.svg" alt="cloud illustration" />
 	</div>
@@ -38,9 +38,17 @@
 			<Experiments />
 		</div>
 	</div>
-</main>
+</div>
 
 <style>
+	.vertical-stack {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		padding: 2rem;
+		gap: 4rem;
+	}
+
 	.panel-grid {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -74,19 +74,12 @@
 	}
 
 	.panel-grid > div:hover {
-		border: 2px solid var(--color-text-highlight);
+		border: 2px solid var(--color-text);
 	}
 
 	.bg-illustration {
 		top: 0;
 		position: absolute;
 		z-index: -10;
-	}
-
-	.content-overview {
-		display: flex;
-		flex-direction: row;
-		align-items: baseline;
-		gap: 1rem;
 	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -49,6 +49,10 @@
 		gap: 4rem;
 	}
 
+	p {
+		padding-top: 6rem;
+	}
+
 	.panel-grid {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));

--- a/src/routes/styles.css
+++ b/src/routes/styles.css
@@ -52,7 +52,7 @@ a {
 }
 
 a:hover {
-	color: var(--color-text-highlight);
+	color: var(--color-text);
 }
 
 h1 {


### PR DESCRIPTION
Home page was all squished due to mismatch style selecting.

Before:
![image](https://github.com/user-attachments/assets/d8c85cff-a554-4381-83e0-c28084f83d22)

After:
![image](https://github.com/user-attachments/assets/987b1973-3ef2-43dc-bdde-524eada8bae3)

I also fixed the edges of the header. It was due to it being a flex container and the edge svgs were shrinking.

Also removed margins on the tile headers to make the tiles more compact.