### PR TITLE
Componentize article items

### DIFF
--- a/src/articles/the-web-appstore-in-disguise.md
+++ b/src/articles/the-web-appstore-in-disguise.md
@@ -1,5 +1,5 @@
 ---
-title: The web, an app store in disgues
+title: The web, an app store in disguise
 description: 
 categories:
   - rust
@@ -14,4 +14,12 @@ Web 1.0 => Web 2.0
 App store a dirty word
 What is a document? What is an app? What is an app store?
 
+# Who did the web evolve the way it did?
+Historical context. What could have doomed the web.
+
+# Issues with the direction the emerging web took
+
 # What if the WebStore 1.0 was made today?
+
+# Final words
+I mean, hope not totally final!

--- a/src/components/ArticleItem.svelte
+++ b/src/components/ArticleItem.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import { formatDate } from '$lib/dateTime'
+	import type { Article } from '$lib/types'
+
+    export let article: Article
+</script>
+
+
+<a href={'/article/' + article.slug} class="article-recent-link">
+    <li>
+        <div class="header">
+            <span class="title">{article.title}</span>
+        </div>
+        <div class="footer">
+            <p class="date">{formatDate(article.updated)}</p>
+        </div>
+    </li>
+</a>
+
+<style>
+	li {
+		padding: 0.6rem 0.7rem;
+		border-radius: 1.5rem;
+	}
+
+	.title {
+		font-size: 1.2rem;
+	}
+
+	.footer {
+		font-size: 0.8rem;
+	}
+</style>

--- a/src/components/ArticleItem.svelte
+++ b/src/components/ArticleItem.svelte
@@ -7,24 +7,26 @@
 
 
 <a href={'/article/' + article.slug} class="article-recent-link">
-    <li>
+    <div>
         <div class="header">
             <span class="title">{article.title}</span>
         </div>
         <div class="footer">
-            <p class="date">{formatDate(article.updated)}</p>
+            <p>{formatDate(article.updated)}</p>
         </div>
-    </li>
+    </div>
 </a>
 
 <style>
-	li {
-		padding: 0.6rem 0.7rem;
-		border-radius: 1.5rem;
-	}
+    a:hover, a:visited, a:link, a:active
+    {
+        text-decoration: none;
+    }
 
 	.title {
 		font-size: 1.2rem;
+        color: white;
+        text-decoration: none;
 	}
 
 	.footer {

--- a/src/components/tiles/MostRecentPosts.svelte
+++ b/src/components/tiles/MostRecentPosts.svelte
@@ -10,16 +10,20 @@
 </script>
 
 <h2>Most recent articles</h2>
+<hr />
 <nav>
-	<ol>
-		{#each data.articles.sort((a, b) => new Date(a.updated).getTime() - new Date(b.updated).getTime()) as article}
-			<ArticleItem article={article} />
-		{/each}
-	</ol>
+	{#each data.articles.sort((a, b) => new Date(a.updated).getTime() - new Date(b.updated).getTime()) as article}
+		<ArticleItem article={article} />
+	{/each}
 </nav>
 
 <style>
 	h2 {
 		margin: 0px;
+	}
+
+	hr {
+		margin: 1rem 0px 1rem 0px;
+		color: var(--color-text);
 	}
 </style>

--- a/src/components/tiles/MostRecentPosts.svelte
+++ b/src/components/tiles/MostRecentPosts.svelte
@@ -1,45 +1,24 @@
 <script lang="ts">
-	import type { Article } from '$lib/types';
+	import type { Article } from '$lib/types'
+	import ArticleItem from '../ArticleItem.svelte'
 
 	interface ArticlesData {
 		articles: Array<Article>;
 	}
 
-	export let data: ArticlesData;
+	export let data: ArticlesData
 </script>
 
 <h2>Most recent articles</h2>
 <nav>
 	<ol>
-		{#each data.articles as article}
-			<a href={'/article/' + article.slug} class="article-recent-link">
-				<li>
-					<div class="header">
-						<span class="title">{article.title}</span>
-					</div>
-					<div class="footer">
-						<p class="date">{article.created}</p>
-					</div>
-				</li>
-			</a>
+		{#each data.articles.sort((a, b) => new Date(a.updated).getTime() - new Date(b.updated).getTime()) as article}
+			<ArticleItem article={article} />
 		{/each}
 	</ol>
 </nav>
 
 <style>
-	.article-recent-link > li {
-		padding: 0.6rem 0.7rem;
-		border-radius: 1.5rem;
-	}
-
-	.article-recent-link .title {
-		font-size: 1.2rem;
-	}
-
-	.article-recent-link .footer {
-		font-size: 0.8rem;
-	}
-
 	h2 {
 		margin: 0px;
 	}

--- a/src/lib/dateTime.ts
+++ b/src/lib/dateTime.ts
@@ -1,0 +1,11 @@
+type DateStyle = Intl.DateTimeFormatOptions['dateStyle']
+
+export function formatDate(date: string | Date, dateStyle: DateStyle = 'medium', locales = 'en') {
+	// Safari is mad about dashes in the date
+	const dateFormatter = new Intl.DateTimeFormat(locales, { dateStyle })
+	if (typeof date === 'string') {
+		return dateFormatter.format(new Date(date))
+	}
+
+	return dateFormatter.format(date)
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,9 +4,8 @@ export type Article = {
 	title: string
 	slug: string
 	description: string
-	date: string
-	created: string
-	updated: string
+	created: Date
+	updated: Date
 	categories: Categories[]
 	published: boolean
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -56,6 +56,9 @@
 		gap: 1rem;
 	}
 	
+	
+
+
 
 	/* @media only screen and (max-width: 768px) {
 		main {
@@ -74,9 +77,4 @@
 		border: 2px solid var(--color-text);
 	}
 
-	.bg-illustration {
-		top: 0;
-		position: absolute;
-		z-index: -10;
-	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -22,16 +22,16 @@
 		<a href="https://maggieappleton.com/garden-history?ref=ideasurg.pub">Maggie Appleton's description</a>.
 	</p>
 	<div class="panel-grid">
-		<div>
-			<AboutMe />
-		</div>
-		<div>
-			<AboutApp />
-		</div>
-		<div>
+		<div id="most-recent-panel">
 			<MostRecentPosts data={data} />
 		</div>
-		<div>
+		<div id="about-me-panel">
+			<AboutMe />
+		</div>
+		<div id="about-app-panel">
+			<AboutApp />
+		</div>
+		<div id="experiments-panel">
 			<Experiments />
 		</div>
 	</div>
@@ -51,14 +51,29 @@
 	}
 
 	.panel-grid {
+		width: 80%;
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+		grid-template-rows: repeat(auto-fit, minmax(100, 1fr));
 		gap: 1rem;
 	}
-	
-	
 
-
+	#most-recent-panel {
+		grid-column: 1;
+		grid-row: 1 / 3;
+	}
+	#about-me-panel {
+		grid-column: 3;
+		grid-row: 1;
+	}
+	#about-app-panel {
+		grid-column: 3;
+		grid-row: 2;
+	}
+	#experiments-panel {
+		grid-column: 2;
+		grid-row: 1;
+	}
 
 	/* @media only screen and (max-width: 768px) {
 		main {

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -2,7 +2,13 @@ import type { Article } from "$lib/types.ts"
 import type { Load } from "@sveltejs/kit"
 
 export const load: Load = async ({ fetch }) => {
-	const response = await fetch('api/articles')
-	const articles: Article[] = await response.json()
+	const response = await fetch('api/articles').then((data) => data.text())
+	// Attempt to parse any Date parsable fields
+	const articles: Article[] = JSON.parse(response, (key, value) => {
+		if (!isNaN(Date.parse(value))) {
+			return new Date(value)
+		}
+		return value
+	})
 	return { articles }
 }


### PR DESCRIPTION
# Improve tiling layout
Move recent articles to the far left and let it extend, bringing some asymmetry to the tiling.

# Improve `Date` handling of articles
Load the article date fields as `Date` objects as opposed to `string`. This is done by attempting parsing of each string to `Date`.
Note: still missing validation and error handling. Types could be misaligned between articles.
Also changed the formatting date function to accept `string | Date`.

# Create `<ArticleItem/ >` to standardize rendering of Articles
This should make it easier to make the tiles look more similar.

# Minor content update
Adding a bit more scaffolding to the web appstore article.